### PR TITLE
Decoupling Physical Storage Notions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0 (TBD)
+
+Additions:
+
+* Decoupled storage: `Burner::Disks` factory, `Burner::Disks::Local` reference implementation, and `b/io/*` `disk` option for configuring IO jobs to use custom disks.
 # 1.2.0 (November 25th, 2020)
 
 #### Enhancements:

--- a/README.md
+++ b/README.md
@@ -236,9 +236,11 @@ This library only ships with very basic, rudimentary jobs that are meant to just
 
 #### IO
 
-* **b/io/exist** [path, short_circuit]: Check to see if a file exists. The path parameter can be interpolated using `Payload#params`.  If short_circuit was set to true (defaults to false) and the file does not exist then the pipeline will be short-circuited.
-* **b/io/read** [binary, path, register]: Read in a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+read mode.
-* **b/io/write** [binary, path, register]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.
+By default all jobs will use the `Burner::Disks::Local` disk for its persistence.  But this is configurable by implementing and registering custom disk-based classes in the `Burner::Disks` factory.  For example: a consumer application may also want to interact with cloud-based storage providers and could leverage this as its job library instead of implementing custom jobs.
+
+* **b/io/exist** [disk, path, short_circuit]: Check to see if a file exists. The path parameter can be interpolated using `Payload#params`.  If short_circuit was set to true (defaults to false) and the file does not exist then the pipeline will be short-circuited.
+* **b/io/read** [binary, disk, path, register]: Read in a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+read mode.
+* **b/io/write** [binary, disk, path, register]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.
 
 #### Serialization
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pipeline = {
     {
       name: :output_value,
       type: 'b/echo',
-      message: 'The current value is: {__value}'
+      message: 'The current value is: {__default_register}'
     },
     {
       name: :parse,
@@ -89,7 +89,7 @@ Some notes:
 
 * Some values are able to be string-interpolated using the provided Payload#params.  This allows for the passing runtime configuration/data into pipelines/jobs.
 * The job's ID can be accessed using the `__id` key.
-* The current job's payload value can be accessed using the `__value` key.
+* The current payload registers' values can be accessed using the `__<register_name>_register` key.
 * Jobs can be re-used (just like the output_id and output_value jobs).
 * If steps is nil then all jobs will execute in their declared order.
 
@@ -163,7 +163,7 @@ jobs:
 
   - name: output_value
     type: b/echo
-    message: 'The current value is: {__value}'
+    message: 'The current value is: {__default_register}'
 
   - name: parse
     type: b/deserialize/json
@@ -301,7 +301,7 @@ pipeline = {
     {
       name: :output_value,
       type: 'b/echo',
-      message: 'The current value is: {__value}'
+      message: 'The current value is: {__default_register}'
     },
     {
       name: :parse,

--- a/lib/burner.rb
+++ b/lib/burner.rb
@@ -10,6 +10,7 @@
 require 'acts_as_hashable'
 require 'benchmark'
 require 'csv'
+require 'fileutils'
 require 'forwardable'
 require 'hash_math'
 require 'hashematics'
@@ -23,6 +24,7 @@ require 'time'
 require 'yaml'
 
 # Common/Shared
+require_relative 'burner/disks'
 require_relative 'burner/modeling'
 require_relative 'burner/side_effects'
 require_relative 'burner/util'

--- a/lib/burner/disks.rb
+++ b/lib/burner/disks.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'disks/local'
+
+module Burner
+  # A factory to register and emit instances that conform to the Disk interface with requests
+  # the instance responds to: #exist?, #read, and #write.  See an example implementation within
+  # the lib/burner/disks directory.
+  #
+  # The benefit to this pluggable disk model is a consumer application can decide which file
+  # backend to use and how to store files.  For example: an application may choose to use
+  # some cloud provider with their own file store implementation.  This can be wrapped up
+  # in a Disk class and registered here and then referenced in the Pipeline's IO jobs.
+  class Disks
+    acts_as_hashable_factory
+
+    register 'local', '', Disks::Local
+  end
+end

--- a/lib/burner/disks/local.rb
+++ b/lib/burner/disks/local.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Burner
+  class Disks
+    # Operations against the local file system.
+    class Local
+      acts_as_hashable
+
+      # Check to see if the passed in path exists within the local file system.
+      # It will not make assumptions on what the 'file' is, only that it is recognized
+      # by Ruby's File class.
+      def exist?(path)
+        File.exist?(path)
+      end
+
+      # Open and read the contents of a local file.  If binary is passed in as true then the file
+      # will be opened in binary mode.
+      def read(path, binary: false)
+        File.open(path, read_mode(binary), &:read)
+      end
+
+      # Open and write the specified data to a local file.  If binary is passed in as true then
+      # the file will be opened in binary mode.  It is important to note that if the file's
+      # directory structure will be automatically created if it does not exist.
+      def write(path, data, binary: false)
+        ensure_directory_exists(path)
+
+        File.open(path, write_mode(binary)) { |io| io.write(data) }
+
+        path
+      end
+
+      private
+
+      def ensure_directory_exists(path)
+        dirname = File.dirname(path)
+
+        return if File.exist?(dirname)
+
+        FileUtils.mkdir_p(dirname)
+
+        nil
+      end
+
+      def write_mode(binary)
+        binary ? 'wb' : 'w'
+      end
+
+      def read_mode(binary)
+        binary ? 'rb' : 'r'
+      end
+    end
+  end
+end

--- a/lib/burner/library/io/base.rb
+++ b/lib/burner/library/io/base.rb
@@ -12,13 +12,14 @@ module Burner
     module IO
       # Common configuration/code for all IO Job subclasses.
       class Base < JobWithRegister
-        attr_reader :path
+        attr_reader :disk, :path
 
-        def initialize(name:, path:, register: DEFAULT_REGISTER)
+        def initialize(name:, path:, disk: {}, register: DEFAULT_REGISTER)
           super(name: name, register: register)
 
           raise ArgumentError, 'path is required' if path.to_s.empty?
 
+          @disk = Disks.make(disk)
           @path = path.to_s
         end
       end

--- a/lib/burner/library/io/exist.rb
+++ b/lib/burner/library/io/exist.rb
@@ -7,8 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-require_relative 'base'
-
 module Burner
   module Library
     module IO
@@ -17,13 +15,14 @@ module Burner
       #
       # Note: this does not use Payload#registers.
       class Exist < Job
-        attr_reader :path, :short_circuit
+        attr_reader :disk, :path, :short_circuit
 
-        def initialize(name:, path:, short_circuit: false)
+        def initialize(name:, path:, disk: {}, short_circuit: false)
           super(name: name)
 
           raise ArgumentError, 'path is required' if path.to_s.empty?
 
+          @disk          = Disks.make(disk)
           @path          = path.to_s
           @short_circuit = short_circuit || false
         end
@@ -31,7 +30,7 @@ module Burner
         def perform(output, payload)
           compiled_path = job_string_template(path, output, payload)
 
-          exists = File.exist?(compiled_path)
+          exists = disk.exist?(compiled_path)
           verb   = exists ? 'does' : 'does not'
 
           output.detail("The path: #{compiled_path} #{verb} exist")

--- a/lib/burner/library/io/open_file_base.rb
+++ b/lib/burner/library/io/open_file_base.rb
@@ -10,17 +10,20 @@
 module Burner
   module Library
     module IO
-      # Common configuration/code for all IO Job subclasses.
-      class Base < JobWithRegister
-        attr_reader :disk, :path
+      # Common configuration/code for all IO Job subclasses that open a file.
+      class OpenFileBase < JobWithRegister
+        attr_reader :binary, :disk, :path
 
-        def initialize(name:, path:, disk: {}, register: DEFAULT_REGISTER)
+        def initialize(name:, path:, binary: false, disk: {}, register: DEFAULT_REGISTER)
           super(name: name, register: register)
 
           raise ArgumentError, 'path is required' if path.to_s.empty?
 
-          @disk = Disks.make(disk)
-          @path = path.to_s
+          @binary = binary || false
+          @disk   = Disks.make(disk)
+          @path   = path.to_s
+
+          freeze
         end
       end
     end

--- a/lib/burner/library/io/read.rb
+++ b/lib/burner/library/io/read.rb
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-require_relative 'base'
+require_relative 'open_file_base'
 
 module Burner
   module Library
@@ -16,17 +16,7 @@ module Burner
       #
       # Expected Payload[register] input: nothing.
       # Payload[register] output: contents of the specified file.
-      class Read < Base
-        attr_reader :binary
-
-        def initialize(name:, path:, binary: false, disk: {}, register: DEFAULT_REGISTER)
-          super(disk: disk, name: name, path: path, register: register)
-
-          @binary = binary || false
-
-          freeze
-        end
-
+      class Read < OpenFileBase
         def perform(output, payload)
           compiled_path = job_string_template(path, output, payload)
 

--- a/lib/burner/library/io/read.rb
+++ b/lib/burner/library/io/read.rb
@@ -19,8 +19,8 @@ module Burner
       class Read < Base
         attr_reader :binary
 
-        def initialize(name:, path:, binary: false, register: DEFAULT_REGISTER)
-          super(name: name, path: path, register: register)
+        def initialize(name:, path:, binary: false, disk: {}, register: DEFAULT_REGISTER)
+          super(disk: disk, name: name, path: path, register: register)
 
           @binary = binary || false
 
@@ -32,13 +32,7 @@ module Burner
 
           output.detail("Reading: #{compiled_path}")
 
-          payload[register] = File.open(compiled_path, mode, &:read)
-        end
-
-        private
-
-        def mode
-          binary ? 'rb' : 'r'
+          payload[register] = disk.read(compiled_path, binary: binary)
         end
       end
     end

--- a/lib/burner/library/io/write.rb
+++ b/lib/burner/library/io/write.rb
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 #
 
-require_relative 'base'
+require_relative 'open_file_base'
 
 module Burner
   module Library
@@ -16,17 +16,7 @@ module Burner
       #
       # Expected Payload[register] input: anything.
       # Payload[register] output: whatever was passed in.
-      class Write < Base
-        attr_reader :binary
-
-        def initialize(name:, path:, binary: false, disk: {}, register: DEFAULT_REGISTER)
-          super(disk: disk, name: name, path: path, register: register)
-
-          @binary = binary || false
-
-          freeze
-        end
-
+      class Write < OpenFileBase
         def perform(output, payload)
           logical_filename  = job_string_template(path, output, payload)
           physical_filename = nil

--- a/lib/burner/version.rb
+++ b/lib/burner/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Burner
-  VERSION = '1.3.0'
+  VERSION = '1.3.0-alpha'
 end

--- a/lib/burner/version.rb
+++ b/lib/burner/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Burner
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
The IO jobs currently only work against the local file system through Ruby's File API.  If a consumer application needs to introduce a new backend then their only option is to add new jobs.  This is not a bad approach, as consumers are free to plugin any custom jobs they wish.  The problem is this may end up with some duplicated logic from burner into consumer applications.  For example, diff comparing our internal consumer application's S3 jobs with burner's IO jobs is almost a 1:1, with the exception of the physical calls to either S3's SDK API or Ruby's File API.

This PR introduces a new pluggable mechanic into the core of burner: disks.  The disk API can allow for multiple backends/physical storage API's to be plugged into the core IO jobs.  By default burner only ships one disk: local, which is just a split from the IO jobs themselves.