### PR TITLE
Readers, Zippers, and Byte Order Marks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.0 (TBD)
+
+Added Jobs:
+
+* b/compress/row_reader
+* b/io/row_reader
 # 1.3.0 (December 11th, 2020)
 
 Additions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.4.0 (TBD)
 
+Additions:
+
+* byte_order_mark option for b/serialize/csv job
+
 Added Jobs:
 
 * b/compress/row_reader

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ By default all jobs will use the `Burner::Disks::Local` disk for its persistence
 
 #### Serialization
 
-* **b/serialize/csv** [register]: Take an array of arrays and create a CSV.
+* **b/serialize/csv** [byte_order_mark, register]: Take an array of arrays and create a CSV.  You can optionally pre-pend a byte order mark, see Burner::Modeling::ByteOrderMark for acceptable options.
 * **b/serialize/json** [register]: Convert value to JSON.
 * **b/serialize/yaml** [register]: Convert value to YAML.
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ This library only ships with very basic, rudimentary jobs that are meant to just
 * **b/collection/validate** [invalid_register, join_char, message_key, register, separator, validations]: Take an array of objects, run it through each declared validator, and split the objects into two registers.  The valid objects will be split into the current register while the invalid ones will go into the invalid_register as declared.  Optional arguments, join_char and message_key, help determine the compiled error messages.  The separator option can be utilized to use dot-notation for validating keys.  See each validation's options by viewing their classes within the `lib/modeling/validations` directory.
 * **b/collection/values** [include_keys, register]: Take an array of objects and call `#values` on each object. If include_keys is true (it is false by default), then call `#keys` on the first object and inject that as a "header" object.
 
+#### Compression
+
+* **b/compress/row_reader** [data_key, ignore_blank_path, ignore_blank_data, path_key, register, separator]: Iterates over an array of objects, extracts a path and data in each object, and creates a zip file.
+
 #### De-serialization
 
 * **b/deserialize/csv** [register]: Take a CSV string and de-serialize into object(s).  Currently it will return an array of arrays, with each nested array representing one row.
@@ -240,7 +244,7 @@ By default all jobs will use the `Burner::Disks::Local` disk for its persistence
 
 * **b/io/exist** [disk, path, short_circuit]: Check to see if a file exists. The path parameter can be interpolated using `Payload#params`.  If short_circuit was set to true (defaults to false) and the file does not exist then the pipeline will be short-circuited.
 * **b/io/read** [binary, disk, path, register]: Read in a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+read mode.
-* **b/io/row_reader** [data_key, disk, ignore_blank_path, ignore_file_not_found, path_key, register]: Iterates over an array of objects, extracts a filepath from a key in each object, and attempts to load the file's content for each record.  The file's content will be stored at the specified data_key. By default missing paths or files will be treated as hard errors.  If you wish to ignore these then pass in true for ignore_blank_path and/or ignore_file_not_found.
+* **b/io/row_reader** [data_key, disk, ignore_blank_path, ignore_file_not_found, path_key, register, separator]: Iterates over an array of objects, extracts a filepath from a key in each object, and attempts to load the file's content for each record.  The file's content will be stored at the specified data_key. By default missing paths or files will be treated as hard errors.  If you wish to ignore these then pass in true for ignore_blank_path and/or ignore_file_not_found.
 * **b/io/write** [binary, disk, path, register]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.
 
 #### Serialization

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ By default all jobs will use the `Burner::Disks::Local` disk for its persistence
 
 * **b/io/exist** [disk, path, short_circuit]: Check to see if a file exists. The path parameter can be interpolated using `Payload#params`.  If short_circuit was set to true (defaults to false) and the file does not exist then the pipeline will be short-circuited.
 * **b/io/read** [binary, disk, path, register]: Read in a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+read mode.
+* **b/io/row_reader** [data_key, disk, ignore_blank_path, ignore_file_not_found, path_key, register]: Iterates over an array of objects, extracts a filepath from a key in each object, and attempts to load the file's content for each record.  The file's content will be stored at the specified data_key. By default missing paths or files will be treated as hard errors.  If you wish to ignore these then pass in true for ignore_blank_path and/or ignore_file_not_found.
 * **b/io/write** [binary, disk, path, register]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.
 
 #### Serialization

--- a/burner.gemspec
+++ b/burner.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency('hash_math', '~>1.2')
   s.add_dependency('objectable', '~>1.0')
   s.add_dependency('realize', '~>1.3')
+  s.add_dependency('rubyzip', '~>1.2')
   s.add_dependency('stringento', '~>2.1')
 
   s.add_development_dependency('guard-rspec', '~>4.7')

--- a/lib/burner.rb
+++ b/lib/burner.rb
@@ -22,6 +22,7 @@ require 'singleton'
 require 'stringento'
 require 'time'
 require 'yaml'
+require 'zip'
 
 # Common/Shared
 require_relative 'burner/disks'

--- a/lib/burner/jobs.rb
+++ b/lib/burner/jobs.rb
@@ -35,6 +35,8 @@ module Burner
     register 'b/collection/values',            Library::Collection::Values
     register 'b/collection/validate',          Library::Collection::Validate
 
+    register 'b/compress/row_reader',          Library::Compress::RowReader
+
     register 'b/deserialize/csv',              Library::Deserialize::Csv
     register 'b/deserialize/json',             Library::Deserialize::Json
     register 'b/deserialize/yaml',             Library::Deserialize::Yaml

--- a/lib/burner/jobs.rb
+++ b/lib/burner/jobs.rb
@@ -41,6 +41,7 @@ module Burner
 
     register 'b/io/exist',                     Library::IO::Exist
     register 'b/io/read',                      Library::IO::Read
+    register 'b/io/row_reader',                Library::IO::RowReader
     register 'b/io/write',                     Library::IO::Write
 
     register 'b/serialize/csv',                Library::Serialize::Csv

--- a/lib/burner/library.rb
+++ b/lib/burner/library.rb
@@ -26,6 +26,8 @@ require_relative 'library/collection/unpivot'
 require_relative 'library/collection/validate'
 require_relative 'library/collection/values'
 
+require_relative 'library/compress/row_reader'
+
 require_relative 'library/deserialize/csv'
 require_relative 'library/deserialize/json'
 require_relative 'library/deserialize/yaml'

--- a/lib/burner/library.rb
+++ b/lib/burner/library.rb
@@ -32,6 +32,7 @@ require_relative 'library/deserialize/yaml'
 
 require_relative 'library/io/exist'
 require_relative 'library/io/read'
+require_relative 'library/io/row_reader'
 require_relative 'library/io/write'
 
 require_relative 'library/serialize/csv'

--- a/lib/burner/library/compress/row_reader.rb
+++ b/lib/burner/library/compress/row_reader.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Burner
+  module Library
+    module Compress
+      # Iterates over an array of objects, extracts a path and data in each object, and
+      # creates a zip file.  By default, if a path is blank then an ArgumentError will be raised.
+      # If this is undesirable then you can set ignore_blank_path to true and the record will be
+      # skipped.  You also have the option to supress blank files being added by configuring
+      # ignore_blank_data as true.
+      #
+      # Expected Payload[register] input: array of objects.
+      # Payload[register] output: compressed binary zip file contents.
+      class RowReader < JobWithRegister
+        DEFAULT_DATA_KEY = 'data'
+        DEFAULT_PATH_KEY = 'path'
+
+        attr_reader :data_key,
+                    :ignore_blank_data,
+                    :ignore_blank_path,
+                    :path_key,
+                    :resolver
+
+        def initialize(
+          name:,
+          data_key: DEFAULT_DATA_KEY,
+          ignore_blank_data: false,
+          ignore_blank_path: false,
+          path_key: DEFAULT_PATH_KEY,
+          register: DEFAULT_REGISTER,
+          separator: ''
+        )
+          super(name: name, register: register)
+
+          @data_key          = data_key.to_s
+          @ignore_blank_data = ignore_blank_data || false
+          @ignore_blank_path = ignore_blank_path || false
+          @path_key          = path_key.to_s
+          @resolver          = Objectable.resolver(separator: separator)
+
+          freeze
+        end
+
+        def perform(output, payload)
+          io = Zip::OutputStream.write_buffer do |zio|
+            array(payload[register]).each.with_index(1) do |record, index|
+              path = resolver.get(record, path_key)
+              data = resolver.get(record, data_key)
+
+              next if assert_and_skip_missing_path?(path, index, output)
+              next if skip_missing_data?(data, index, output)
+
+              path = strip_leading_separator(path)
+
+              zio.put_next_entry(path)
+              zio.write(data)
+            end
+          end
+
+          payload[register] = io.string
+        end
+
+        private
+
+        def strip_leading_separator(path)
+          path.to_s.start_with?(File::SEPARATOR) ? path.to_s[1..-1] : path.to_s
+        end
+
+        def assert_and_skip_missing_path?(path, index, output)
+          if ignore_blank_path && path.to_s.empty?
+            output.detail("Skipping record #{index} because of blank path")
+            true
+          elsif path.to_s.empty?
+            raise ArgumentError, "Record #{index} is missing a path at key: #{path_key}"
+          end
+        end
+
+        def skip_missing_data?(data, index, output)
+          return false unless ignore_blank_data && data.to_s.empty?
+
+          output.detail("Skipping record #{index} because of blank data")
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/burner/library/compress/row_reader.rb
+++ b/lib/burner/library/compress/row_reader.rb
@@ -55,12 +55,12 @@ module Burner
         def perform(output, payload)
           payload[register] = Zip::OutputStream.write_buffer do |zip|
             array(payload[register]).each.with_index(1) do |record, index|
-              contents = extract_path_and_data(record, index, output)
+              content = extract_path_and_data(record, index, output)
 
-              next unless contents
+              next unless content
 
-              zip.put_next_entry(contents.path)
-              zip.write(contents.data)
+              zip.put_next_entry(content.path)
+              zip.write(content.data)
             end
           end.string
         end

--- a/lib/burner/library/io/row_reader.rb
+++ b/lib/burner/library/io/row_reader.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require_relative 'open_file_base'
+
+module Burner
+  module Library
+    module IO
+      # Iterates over an array of objects, extracts a filepath from a key in each object,
+      # and attempts to load the file's content for each record.  The file's content will be
+      # stored at the specified data_key. By default missing paths or files will be
+      # treated as hard errors.  If you wish to ignore these then pass in true for
+      # ignore_blank_path and/or ignore_file_not_found.
+      #
+      # Expected Payload[register] input: array of objects.
+      # Payload[register] output: array of objects.
+      class RowReader < JobWithRegister
+        class FileNotFoundError < StandardError; end
+
+        DEFAULT_DATA_KEY = 'data'
+        DEFAULT_PATH_KEY = 'path'
+
+        attr_reader :binary,
+                    :data_key,
+                    :disk,
+                    :ignore_blank_path,
+                    :ignore_file_not_found,
+                    :path_key,
+                    :resolver
+
+        def initialize(
+          name:,
+          binary: false,
+          data_key: DEFAULT_DATA_KEY,
+          disk: {},
+          ignore_blank_path: false,
+          ignore_file_not_found: false,
+          path_key: DEFAULT_PATH_KEY,
+          register: DEFAULT_REGISTER,
+          separator: ''
+        )
+          super(name: name, register: register)
+
+          @binary                = binary || false
+          @data_key              = data_key.to_s
+          @disk                  = Disks.make(disk)
+          @ignore_blank_path     = ignore_blank_path || false
+          @ignore_file_not_found = ignore_file_not_found || false
+          @path_key              = path_key.to_s
+          @resolver              = Objectable.resolver(separator: separator)
+
+          freeze
+        end
+
+        def perform(output, payload)
+          records = array(payload[register])
+
+          output.detail("Reading path_key: #{path_key} for #{payload[register].length} records(s)")
+          output.detail("Storing read data in: #{path_key}")
+
+          payload[register] = records.map.with_index(1) do |object, index|
+            load_data(object, index, output)
+          end
+        end
+
+        private
+
+        def assert_and_skip_missing_path?(path, index, output)
+          missing_path            = path.to_s.empty?
+          blank_path_raises_error = !ignore_blank_path
+
+          if missing_path && blank_path_raises_error
+            output.detail("Record #{index} is missing a path, raising error")
+
+            raise ArgumentError, "Record #{index} is missing a path"
+          elsif missing_path
+            output.detail("Record #{index} is missing a path")
+
+            true
+          end
+        end
+
+        def assert_and_skip_file_not_found?(path, index, output)
+          does_not_exist              = !disk.exist?(path)
+          file_not_found_raises_error = !ignore_file_not_found
+
+          if file_not_found_raises_error && does_not_exist
+            output.detail("Record #{index} path: '#{path}' does not exist, raising error")
+
+            raise FileNotFoundError, "#{path} does not exist"
+          elsif does_not_exist
+            output.detail("Record #{index} path: '#{path}' does not exist, skipping")
+
+            true
+          end
+        end
+
+        def load_data(object, index, output)
+          path = resolver.get(object, path_key)
+
+          return object if assert_and_skip_missing_path?(path, index, output)
+          return object if assert_and_skip_file_not_found?(path, index, output)
+
+          data = disk.read(path, binary: binary)
+
+          resolver.set(object, data_key, data)
+
+          object
+        end
+      end
+    end
+  end
+end

--- a/lib/burner/library/serialize/csv.rb
+++ b/lib/burner/library/serialize/csv.rb
@@ -10,13 +10,26 @@
 module Burner
   module Library
     module Serialize
-      # Take an array of arrays and create a CSV.
+      # Take an array of arrays and create a CSV.  You can optionally pre-pend a byte order mark,
+      # see Burner::Modeling::ByteOrderMark for acceptable options.
       #
       # Expected Payload[register] input: array of arrays.
       # Payload[register] output: a serialized CSV string.
       class Csv < JobWithRegister
+        attr_reader :byte_order_mark
+
+        def initialize(name:, byte_order_mark: nil, register: DEFAULT_REGISTER)
+          super(name: name, register: register)
+
+          @byte_order_mark = Modeling::ByteOrderMark.resolve(byte_order_mark)
+
+          freeze
+        end
+
         def perform(_output, payload)
           payload[register] = CSV.generate(options) do |csv|
+            csv.to_io.write(byte_order_mark) if byte_order_mark
+
             array(payload[register]).each do |row|
               csv << row
             end

--- a/lib/burner/library/serialize/csv.rb
+++ b/lib/burner/library/serialize/csv.rb
@@ -27,13 +27,13 @@ module Burner
         end
 
         def perform(_output, payload)
-          payload[register] = CSV.generate(options) do |csv|
-            csv.to_io.write(byte_order_mark) if byte_order_mark
-
+          serialized_rows = CSV.generate(options) do |csv|
             array(payload[register]).each do |row|
               csv << row
             end
           end
+
+          payload[register] = "#{byte_order_mark}#{serialized_rows}"
         end
 
         private

--- a/lib/burner/modeling.rb
+++ b/lib/burner/modeling.rb
@@ -9,6 +9,7 @@
 
 require_relative 'modeling/attribute'
 require_relative 'modeling/attribute_renderer'
+require_relative 'modeling/byte_order_mark'
 require_relative 'modeling/key_index_mapping'
 require_relative 'modeling/key_mapping'
 require_relative 'modeling/validations'

--- a/lib/burner/modeling/byte_order_mark.rb
+++ b/lib/burner/modeling/byte_order_mark.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Burner
+  module Modeling
+    # Define all acceptable byte order mark values.
+    module ByteOrderMark
+      UTF_8    = "\xEF\xBB\xBF"
+      UTF_16BE = "\xFE\xFF"
+      UTF_16LE = "\xFF\xFE"
+      UTF_32BE = "\x00\x00\xFE\xFF"
+      UTF_32LE = "\xFE\xFF\x00\x00"
+
+      class << self
+        def resolve(value)
+          value ? const_get(value.to_s.upcase.to_sym) : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/burner/version.rb
+++ b/lib/burner/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Burner
-  VERSION = '1.3.0'
+  VERSION = '1.4.0-alpha'
 end

--- a/spec/burner/library/compress/row_reader_spec.rb
+++ b/spec/burner/library/compress/row_reader_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+require 'zip_helper'
+
+describe Burner::Library::Compress::RowReader do
+  let(:value) do
+    [
+      {
+        path: 'hello.txt',
+        data: 'Hello World!'
+      },
+      {
+        path: 'a/b/c/foobar.txt',
+        data: 'foobar'
+      },
+    ]
+  end
+
+  let(:string_out)        { StringIO.new }
+  let(:output)            { Burner::Output.new(outs: [string_out]) }
+  let(:register)          { 'register_a' }
+  let(:payload)           { Burner::Payload.new(registers: { register => value }) }
+  let(:ignore_blank_path) { false }
+  let(:ignore_blank_data) { false }
+
+  subject do
+    described_class.make(
+      ignore_blank_data: ignore_blank_data,
+      ignore_blank_path: ignore_blank_path,
+      name: 'test',
+      register: register
+    )
+  end
+
+  describe '#perform' do
+    it 'creates zip' do
+      subject.perform(output, payload)
+
+      actual              = payload[register]
+      decompressed_actual = decompress(actual)
+
+      expected = {
+        'hello.txt' => 'Hello World!',
+        'a/b/c/foobar.txt' => 'foobar'
+      }
+
+      expect(decompressed_actual).to eq(expected)
+    end
+
+    context 'with blank paths' do
+      let(:value) do
+        [
+          {
+            path: '',
+            data: 'Hello World!'
+          },
+          {
+            path: 'a/b/c/foobar.txt',
+            data: 'foobar'
+          },
+        ]
+      end
+
+      context 'ignoring blank paths' do
+        let(:ignore_blank_path) { true }
+
+        it 'creates zip' do
+          subject.perform(output, payload)
+
+          actual              = payload[register]
+          decompressed_actual = decompress(actual)
+
+          expected = {
+            'a/b/c/foobar.txt' => 'foobar'
+          }
+
+          expect(decompressed_actual).to eq(expected)
+        end
+      end
+
+      context 'not ignoring blank paths' do
+        it 'raises ArgumentError' do
+          expect { subject.perform(output, payload) }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'when ignoring blank data' do
+      let(:ignore_blank_data) { true }
+
+      let(:value) do
+        [
+          {
+            path: 'hello1.txt',
+            data: nil
+          },
+          {
+            path: 'hello2.txt',
+            data: ''
+          },
+          {
+            path: 'a/b/c/foobar.txt',
+            data: 'foobar'
+          },
+        ]
+      end
+
+      it 'creates zip' do
+        subject.perform(output, payload)
+
+        actual              = payload[register]
+        decompressed_actual = decompress(actual)
+
+        expected = {
+          'a/b/c/foobar.txt' => 'foobar'
+        }
+
+        expect(decompressed_actual).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/burner/library/io/row_reader_spec.rb
+++ b/spec/burner/library/io/row_reader_spec.rb
@@ -11,7 +11,6 @@ require 'spec_helper'
 
 describe Burner::Library::IO::RowReader do
   let(:path)                  { File.join('spec', 'fixtures', 'basic.txt') }
-  let(:params)                { { path: path } }
   let(:string_out)            { StringIO.new }
   let(:output)                { Burner::Output.new(outs: [string_out]) }
   let(:register)              { 'register_a' }

--- a/spec/burner/library/io/row_reader_spec.rb
+++ b/spec/burner/library/io/row_reader_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe Burner::Library::IO::RowReader do
+  let(:path)                  { File.join('spec', 'fixtures', 'basic.txt') }
+  let(:params)                { { path: path } }
+  let(:string_out)            { StringIO.new }
+  let(:output)                { Burner::Output.new(outs: [string_out]) }
+  let(:register)              { 'register_a' }
+  let(:ignore_blank_path)     { false }
+  let(:ignore_file_not_found) { false }
+
+  let(:file_data) do
+    [
+      { path: File.join('spec', 'fixtures', 'basic.txt') },
+      { path: File.join('spec', 'fixtures', 'cars.csv') }
+    ]
+  end
+
+  let(:payload) do
+    Burner::Payload.new(registers: { register => file_data })
+  end
+
+  subject do
+    described_class.make(
+      ignore_blank_path: ignore_blank_path,
+      ignore_file_not_found: ignore_file_not_found,
+      name: 'test',
+      register: register
+    )
+  end
+
+  describe '#perform' do
+    it "sets payload's value to file contents" do
+      subject.perform(output, payload)
+
+      actual = payload[register].map { |o| o['data'] }
+
+      expected = [
+        "I was read in from disk.\n",
+        "make,model,year\njeep,wrangler,1991\nhonda,accord,2000\n"
+      ]
+
+      expect(actual).to eq(expected)
+    end
+
+    context 'when missing paths' do
+      let(:file_data) do
+        [
+          { path: File.join('spec', 'fixtures', 'basic.txt') },
+          { path: File.join('spec', 'fixtures', 'cars.csv') },
+          { path: '' }
+        ]
+      end
+
+      it 'raises ArgumentError' do
+        expect { subject.perform(output, payload) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when missing files' do
+      let(:file_data) do
+        [
+          { path: File.join('spec', 'fixtures', 'basic.txt') },
+          { path: File.join('spec', 'fixtures', 'cars.csv') },
+          { path: 'does_not_exist.txt' },
+        ]
+      end
+
+      it 'raises FileNotFoundError' do
+        constant = Burner::Library::IO::RowReader::FileNotFoundError
+
+        expect { subject.perform(output, payload) }.to raise_error(constant)
+      end
+    end
+
+    context 'when ignoring missing paths and files' do
+      let(:ignore_blank_path)     { true }
+      let(:ignore_file_not_found) { true }
+
+      let(:file_data) do
+        [
+          { path: File.join('spec', 'fixtures', 'basic.txt') },
+          { path: File.join('spec', 'fixtures', 'cars.csv') },
+          { path: '' },
+          { path: 'does_not_exist.txt' },
+        ]
+      end
+
+      it 'sets contents to nil' do
+        subject.perform(output, payload)
+
+        actual = payload[register].map { |o| o['data'] }
+
+        expected = [
+          "I was read in from disk.\n",
+          "make,model,year\njeep,wrangler,1991\nhonda,accord,2000\n",
+          nil,
+          nil
+        ]
+
+        expect(actual).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/burner/library/serialize/csv_spec.rb
+++ b/spec/burner/library/serialize/csv_spec.rb
@@ -18,12 +18,19 @@ describe Burner::Library::Serialize::Csv do
     ]
   end
 
-  let(:string_out) { StringIO.new }
-  let(:output)     { Burner::Output.new(outs: [string_out]) }
-  let(:register)   { 'register_a' }
-  let(:payload)    { Burner::Payload.new(registers: { register => value }) }
+  let(:string_out)      { StringIO.new }
+  let(:output)          { Burner::Output.new(outs: [string_out]) }
+  let(:register)        { 'register_a' }
+  let(:payload)         { Burner::Payload.new(registers: { register => value }) }
+  let(:byte_order_mark) { nil }
 
-  subject { described_class.make(name: 'test', register: register) }
+  subject do
+    described_class.make(
+      byte_order_mark: byte_order_mark,
+      name: 'test',
+      register: register
+    )
+  end
 
   describe '#perform' do
     it 'serializes and sets value' do
@@ -32,6 +39,18 @@ describe Burner::Library::Serialize::Csv do
       expected = "id,first,last\n1,captain,kangaroo\n2,twisted,sister\n"
 
       expect(payload[register]).to eq(expected)
+    end
+
+    context 'with UTF-8 byte order mark' do
+      let(:byte_order_mark) { 'utf_8' }
+
+      it 'serializes and sets value' do
+        subject.perform(output, payload)
+
+        expected = "\xEF\xBB\xBFid,first,last\n1,captain,kangaroo\n2,twisted,sister\n"
+
+        expect(payload[register]).to eq(expected)
+      end
     end
   end
 end

--- a/spec/zip_helper.rb
+++ b/spec/zip_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+def decompress(data)
+  data_by_name = {}
+  io           = StringIO.new(data)
+
+  Zip::InputStream.open(io) do |zip_io|
+    while (entry = zip_io.get_next_entry)
+      name = entry.name
+      data = zip_io.read
+
+      data_by_name[name] = data
+    end
+  end
+
+  data_by_name
+end


### PR DESCRIPTION
This PR contains three new notions:

1. Loading data for a dynamic list of paths
2. Compressing a dynamic list of paths and data
3. Optional byte order mark for serializing CSV data

Each of the first two notions are implemented in two jobs, respectively:

* **b/io/row_reader**: Given a dataset where each record/object contains a key for a path, this job can iterate over it and load the path's contents into a new key per row.  
* **b/compress/row_reader**: Given a dataset where each record/object contains a key for a path and a key for data, it will create an in-memory zipfile and assign it to the specified register.

The third new notion manifests as a new option in the `b/serialize/csv` job.  It allows for the pre-pending of a byte order mark that indicates the encoding of the file.  While UTF-8 does not technically need this, some applications, such as Microsoft Excel require it for properly reading UTF-8 CSV files.  There are other places this could be beneficial but I chose to only add the specific implementations we need at this time.