### PR TITLE
add collection zip job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+# 1.5.0 (TBD)
+
+Added Jobs:
+
+* b/collection/zip
 # 1.4.0 (December 17th, 2020)
 
 Additions:

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ This library only ships with very basic, rudimentary jobs that are meant to just
 * **b/collection/unpivot** [pivot_set, register]: Take an array of objects and unpivot specific sets of keys into rows.  Under the hood it uses [HashMath's Unpivot class](https://github.com/bluemarblepayroll/hash_math#unpivot-hash-key-coalescence-and-row-extrapolation).
 * **b/collection/validate** [invalid_register, join_char, message_key, register, separator, validations]: Take an array of objects, run it through each declared validator, and split the objects into two registers.  The valid objects will be split into the current register while the invalid ones will go into the invalid_register as declared.  Optional arguments, join_char and message_key, help determine the compiled error messages.  The separator option can be utilized to use dot-notation for validating keys.  See each validation's options by viewing their classes within the `lib/modeling/validations` directory.
 * **b/collection/values** [include_keys, register]: Take an array of objects and call `#values` on each object. If include_keys is true (it is false by default), then call `#keys` on the first object and inject that as a "header" object.
+* **b/collection/zip** [base_register, register, with_register]: Combines `base_register` and `with_register`s' data to form one single array in `register`.  It will combine each element, positionally in each array to form the final array.  For example:  ['hello', 'bugs'] + ['world', 'bunny'] => [['hello', 'world'], ['bugs', 'bunny']]
 
 #### Compression
 

--- a/lib/burner/jobs.rb
+++ b/lib/burner/jobs.rb
@@ -34,6 +34,7 @@ module Burner
     register 'b/collection/unpivot',           Library::Collection::Unpivot
     register 'b/collection/values',            Library::Collection::Values
     register 'b/collection/validate',          Library::Collection::Validate
+    register 'b/collection/zip',               Library::Collection::Zip
 
     register 'b/compress/row_reader',          Library::Compress::RowReader
 

--- a/lib/burner/library.rb
+++ b/lib/burner/library.rb
@@ -25,6 +25,7 @@ require_relative 'library/collection/transform'
 require_relative 'library/collection/unpivot'
 require_relative 'library/collection/validate'
 require_relative 'library/collection/values'
+require_relative 'library/collection/zip'
 
 require_relative 'library/compress/row_reader'
 

--- a/lib/burner/library/collection/zip.rb
+++ b/lib/burner/library/collection/zip.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+module Burner
+  module Library
+    module Collection
+      # This job can take two arrays and coalesces them by index.  For example:
+      #
+      # input:
+      #   base_register: [ 'hello', 'bugs' ]
+      #   with_register: [ 'world', 'bunny' ]
+      # output:
+      #  register: [ ['hello', 'world'], ['bugs', 'bunny'] ]
+      #
+      # Expected Payload[base_register] input: array of objects.
+      # Expected Payload[with_register] input: array of objects.
+      # Payload[register] output: An array of two-dimensional arrays.
+      class Zip < JobWithRegister
+        attr_reader :base_register, :with_register
+
+        def initialize(
+          name:,
+          with_register:,
+          base_register: DEFAULT_REGISTER,
+          register: DEFAULT_REGISTER
+        )
+          super(name: name, register: register)
+
+          @base_register = base_register.to_s
+          @with_register = with_register.to_s
+
+          freeze
+        end
+
+        def perform(output, payload)
+          base_data = array(payload[base_register])
+          with_data = array(payload[with_register])
+
+          output.detail("Combining register: #{base_register} (#{base_data.length} record(s))")
+          output.detail("With register: #{with_register} (#{with_data.length} record(s))")
+
+          payload[register] = base_data.zip(with_data)
+        end
+      end
+    end
+  end
+end

--- a/lib/burner/version.rb
+++ b/lib/burner/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Burner
-  VERSION = '1.4.0'
+  VERSION = '1.5.0-alpha'
 end

--- a/spec/burner/library/collection/zip_spec.rb
+++ b/spec/burner/library/collection/zip_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2020-present, Blue Marble Payroll, LLC
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+require 'spec_helper'
+
+describe Burner::Library::Collection::Zip do
+  let(:base_data)     { %w[hello bugs] }
+  let(:with_data)     { %w[world bunny] }
+  let(:string_out)    { StringIO.new }
+  let(:output)        { Burner::Output.new(outs: [string_out]) }
+  let(:base_register) { 'register_b' }
+  let(:with_register) { 'register_c' }
+  let(:register)      { 'register_a' }
+
+  let(:payload) do
+    Burner::Payload.new(
+      registers: {
+        base_register => base_data,
+        with_register => with_data
+      }
+    )
+  end
+
+  subject do
+    described_class.make(
+      name: 'test',
+      base_register: base_register,
+      with_register: with_register,
+      register: register
+    )
+  end
+
+  describe '#perform' do
+    before(:each) { subject.perform(output, payload) }
+
+    it 'sets single zipped array on register' do
+      expected = [
+        %w[hello world],
+        %w[bugs bunny]
+      ]
+
+      expect(payload[register]).to eq(expected)
+    end
+
+    describe 'output' do
+      specify 'contains base_data register name and record count' do
+        expect(string_out.string).to include("#{base_register} (#{base_data.length} record(s))")
+      end
+
+      specify 'contains with_data register name and record count' do
+        expect(string_out.string).to include("#{with_register} (#{with_data.length} record(s))")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby's Array#zip method is pretty simple and allows for combining two arrays, positionally, into one single array.  This can come in handy when performing dynamic array creation from scratch within a no-code environment.  This PR basically exposes that method for Burner pipelines in the form of a job for use.