### PR TITLE
Add supress_side_effect option for io write job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 1.6.0 (TBD)
+
+Additions:
+
+* b/io/write now provides an optional `supress_side_effect` option.
 # 1.5.0 (December 21st, 2020)
 
 Added Jobs:

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ By default all jobs will use the `Burner::Disks::Local` disk for its persistence
 * **b/io/exist** [disk, path, short_circuit]: Check to see if a file exists. The path parameter can be interpolated using `Payload#params`.  If short_circuit was set to true (defaults to false) and the file does not exist then the pipeline will be short-circuited.
 * **b/io/read** [binary, disk, path, register]: Read in a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+read mode.
 * **b/io/row_reader** [data_key, disk, ignore_blank_path, ignore_file_not_found, path_key, register, separator]: Iterates over an array of objects, extracts a filepath from a key in each object, and attempts to load the file's content for each record.  The file's content will be stored at the specified data_key. By default missing paths or files will be treated as hard errors.  If you wish to ignore these then pass in true for ignore_blank_path and/or ignore_file_not_found.
-* **b/io/write** [binary, disk, path, register]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.
+* **b/io/write** [binary, disk, path, register, supress_side_effect]: Write to a local file.  The path parameter can be interpolated using `Payload#params`.  If the contents are binary, pass in `binary: true` to open it up in binary+write mode.  By default, written files are also logged as WrittenFile instances to the Payload#side_effects array.  You can pass in supress_side_effect: true to disable this behavior.
 
 #### Serialization
 

--- a/lib/burner/library/io/write.rb
+++ b/lib/burner/library/io/write.rb
@@ -12,7 +12,9 @@ require_relative 'open_file_base'
 module Burner
   module Library
     module IO
-      # Write value to disk.
+      # Write value to disk.  By default, written files are also logged as WrittenFile
+      # instances to the Payload#side_effects array.  You can pass in
+      # supress_side_effect: true to disable this behavior.
       #
       # Expected Payload[register] input: anything.
       # Payload[register] output: whatever was passed in.

--- a/lib/burner/library/io/write.rb
+++ b/lib/burner/library/io/write.rb
@@ -17,6 +17,27 @@ module Burner
       # Expected Payload[register] input: anything.
       # Payload[register] output: whatever was passed in.
       class Write < OpenFileBase
+        attr_reader :supress_side_effect
+
+        def initialize(
+          name:,
+          path:,
+          binary: false,
+          disk: {},
+          register: DEFAULT_REGISTER,
+          supress_side_effect: false
+        )
+          @supress_side_effect = supress_side_effect || false
+
+          super(
+            binary: binary,
+            disk: disk,
+            name: name,
+            path: path,
+            register: register
+          )
+        end
+
         def perform(output, payload)
           logical_filename  = job_string_template(path, output, payload)
           physical_filename = nil
@@ -28,6 +49,10 @@ module Burner
           end.real
 
           output.detail("Wrote to: #{physical_filename}")
+
+          return if supress_side_effect
+
+          output.detail("Saving to side effects: #{logical_filename}")
 
           side_effect = SideEffects::WrittenFile.new(
             logical_filename: logical_filename,

--- a/lib/burner/version.rb
+++ b/lib/burner/version.rb
@@ -8,5 +8,5 @@
 #
 
 module Burner
-  VERSION = '1.5.0'
+  VERSION = '1.6.0-alpha'
 end

--- a/spec/burner/library/io/write_spec.rb
+++ b/spec/burner/library/io/write_spec.rb
@@ -10,15 +10,26 @@
 require 'spec_helper'
 
 describe Burner::Library::IO::Write do
-  let(:path)       { File.join(TEMP_DIR, "#{SecureRandom.uuid}.txt") }
-  let(:params)     { { path: path } }
-  let(:string_out) { StringIO.new }
-  let(:output)     { Burner::Output.new(outs: [string_out]) }
-  let(:value)      { 'I should be written to disk.' }
-  let(:register)   { 'register_a' }
-  let(:payload)    { Burner::Payload.new(params: params, registers: { register => value }) }
+  let(:path)                { File.join(TEMP_DIR, "#{SecureRandom.uuid}.txt") }
+  let(:params)              { { path: path } }
+  let(:string_out)          { StringIO.new }
+  let(:output)              { Burner::Output.new(outs: [string_out]) }
+  let(:value)               { 'I should be written to disk.' }
+  let(:register)            { 'register_a' }
+  let(:supress_side_effect) { false }
 
-  subject { described_class.make(name: 'test', path: '{path}', register: register) }
+  let(:payload) do
+    Burner::Payload.new(params: params, registers: { register => value })
+  end
+
+  subject do
+    described_class.make(
+      name: 'test',
+      path: '{path}',
+      register: register,
+      supress_side_effect: supress_side_effect
+    )
+  end
 
   describe '#perform' do
     before(:each) do
@@ -35,6 +46,14 @@ describe Burner::Library::IO::Write do
       expect(payload.side_effects.length).to                  eq(1)
       expect(payload.side_effects.first.logical_filename).to  eq(path)
       expect(payload.side_effects.first.physical_filename).to eq(path)
+    end
+
+    context 'when supressing side effect' do
+      let(:supress_side_effect) { true }
+
+      it 'does not add to Payload#side_effects' do
+        expect(payload.side_effects).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
I found a use case where files need to be written and the default b/io/write job is sufficient, but it is being written to a hot folder and is subject to be moved and not available after move.  In order to allow this, the write job can now accept an optional `supress_side_effect` option.